### PR TITLE
feat: add share limit rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.3] - 2026-05-08
+
+- Added share limit rules for applying qBittorrent ratio and seeding-time limits by tag or tracker
+- Share-limited torrents now take priority over torrentManager's automatic pause and cleaner deletion flows
+- Documented share limit rule configuration
+
 ## [1.2.2] - 2026-05-08
 
 - 🦦 Added support for qBittorrent `5.2.0`
@@ -81,6 +87,7 @@
 
 Initial release 🐻 🪄 🦄 🚀
 
+[1.2.3]: https://github.com/tatoalo/torrentManager/releases/tag/1.2.3
 [1.2.2]: https://github.com/tatoalo/torrentManager/releases/tag/1.2.2
 [1.2.1]: https://github.com/tatoalo/torrentManager/releases/tag/1.2.1
 [1.2.0]: https://github.com/tatoalo/torrentManager/releases/tag/1.2.0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ torrentManager can be used to automatically perform operations like:
 * stop seeding process once download of a specific tag or category has completed
 * remove torrents (metadata & files) of a specific tag or category group
 * attach a specific TAG to specific torrents (e.g. *private trackers*) 
+* apply qBittorrent ratio and seeding-time limits to torrents by tag or tracker
 
 The core has been developed in a quick and easy manner, on purpose to be easily extendible, using the very well documented qBittorrent API.
 
@@ -73,6 +74,15 @@ dir_targets = { "cat" = "path", "cat2" = "path" }
 
 [trackers]
 trackers_tags = { "tracker_endpoint" = "tag" }
+
+[[share_limits]]
+name = "private tracker"
+tags = ["tag"]
+trackers = ["tracker_endpoint"]
+ratio_limit = 2.0
+seeding_time_limit = 10080
+inactive_seeding_time_limit = -2
+share_limit_action = "RemoveWithContent"
 ```
 
 #### Custom Scheduling
@@ -109,6 +119,32 @@ trackers_tags = { "tracker_endpoint" = "tag" }
 ```
 
 so that if a torrent is found to possess a tracker like `tracker.tracker_endpoint.forreal`, it will be tagged with `tag`.
+
+#### Share Limit Rules
+
+Share limit rules apply qBittorrent's per-torrent seeding limits to torrents matched by tag, tracker, or both.
+
+```toml
+[[share_limits]]
+name = "private tracker"
+tags = ["tag"]
+trackers = ["tracker_endpoint"]
+ratio_limit = 2.0
+seeding_time_limit = 10080
+inactive_seeding_time_limit = -2
+share_limit_action = "RemoveWithContent"
+```
+
+Within one rule, multiple `tags` are matched as OR conditions and multiple `trackers` are matched as OR conditions. If both selector groups are present, a torrent must match both groups. Tracker selectors are substring matches against qBittorrent tracker URLs. Rules are applied in file order, so a later matching rule can overwrite values from an earlier matching rule.
+
+Torrents matched by a share limit rule are skipped by torrentManager's automatic pause and cleaner deletion flows. This lets qBittorrent enforce the configured ratio or seed-time rule first. Use `share_limit_action = "RemoveWithContent"` when the share limit rule should delete the torrent and its files after the limit is reached.
+
+The supported share limit values mirror qBittorrent:
+
+- `ratio_limit`: max seed ratio; `-2` uses the global value and `-1` disables the ratio limit.
+- `seeding_time_limit`: minutes to seed; `-2` uses the global value and `-1` disables the time limit.
+- `inactive_seeding_time_limit`: inactive minutes; `-2` uses the global value and `-1` disables the inactive time limit.
+- `share_limit_action`: one of `Stop`, `Remove`, `RemoveWithContent`, or `EnableSuperSeeding`.
 
 ## License
 

--- a/configuration_example.toml
+++ b/configuration_example.toml
@@ -17,3 +17,12 @@ dir_targets = { "cat" = "path", "cat2" = "path" }
 
 [trackers]
 trackers_tags = { "tracker_endpoint" = "tag" }
+
+[[share_limits]]
+name = "private tracker"
+tags = ["tag"]
+trackers = ["tracker_endpoint"]
+ratio_limit = 2.0
+seeding_time_limit = 10080
+inactive_seeding_time_limit = -2
+share_limit_action = "RemoveWithContent"

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -11,4 +11,5 @@ if __name__ == "__main__":
         t.add_to_watchdog(category=category)
 
     t.check_trackers()
+    t.apply_share_limits()
     t.check_status()

--- a/src/torrent_configuration.py
+++ b/src/torrent_configuration.py
@@ -1,9 +1,30 @@
 import os
 import sys
+from dataclasses import dataclass, field
+from typing import Any
 
 import tomlkit
 
 from src import CONFIG_PATH, logging
+
+
+SUPPORTED_SHARE_LIMIT_ACTIONS = {
+    "Stop",
+    "Remove",
+    "RemoveWithContent",
+    "EnableSuperSeeding",
+}
+
+
+@dataclass(frozen=True)
+class ShareLimitRule:
+    name: str
+    tags: list[str] = field(default_factory=list)
+    trackers: list[str] = field(default_factory=list)
+    ratio_limit: int | float | None = None
+    seeding_time_limit: int | None = None
+    inactive_seeding_time_limit: int | None = None
+    share_limit_action: str | None = None
 
 
 class TorrentConfiguration:
@@ -20,6 +41,7 @@ class TorrentConfiguration:
         self.dir_targets = {}
 
         self.trackers_tags = {}
+        self.share_limits: list[ShareLimitRule] = []
 
         self._load_configuration()
 
@@ -46,6 +68,15 @@ class TorrentConfiguration:
 
         [trackers]
         trackers_tags = { "tracker_endpoint" = "tag" }
+
+        [[share_limits]]
+        name = "private tracker"
+        tags = ["private"]
+        trackers = ["tracker_endpoint"]
+        ratio_limit = 2.0
+        seeding_time_limit = 10080
+        inactive_seeding_time_limit = -2
+        share_limit_action = "RemoveWithContent"
         """
 
         if not os.path.exists(CONFIG_PATH):
@@ -87,6 +118,8 @@ class TorrentConfiguration:
                     self.dir_targets = inner_section.get("dir_targets")
                 case "trackers":
                     self.trackers_tags = inner_section.get("trackers_tags")
+                case "share_limits":
+                    self.share_limits = self._load_share_limit_rules(inner_section)
                 case _:
                     logging.info(
                         f"Found section {section} in configuration file, skipping this since it wasn't expected..."
@@ -97,3 +130,156 @@ class TorrentConfiguration:
         Retrieve list of categories
         """
         return self.categories
+
+    def _load_share_limit_rules(self, raw_rules: Any) -> list[ShareLimitRule]:
+        if isinstance(raw_rules, dict):
+            logging.error(
+                "Share limit rules must use TOML array tables, e.g. [[share_limits]]"
+            )
+            sys.exit(1)
+
+        rules = []
+        for index, raw_rule in enumerate(raw_rules, start=1):
+            rules.append(self._build_share_limit_rule(raw_rule=raw_rule, index=index))
+
+        return rules
+
+    def _build_share_limit_rule(self, *, raw_rule: Any, index: int) -> ShareLimitRule:
+        name = str(raw_rule.get("name") or f"share_limits[{index}]")
+        tags = self._coerce_string_list(
+            value=raw_rule.get("tags"),
+            field_name="tags",
+            rule_name=name,
+        )
+        trackers = self._coerce_string_list(
+            value=raw_rule.get("trackers"),
+            field_name="trackers",
+            rule_name=name,
+        )
+
+        if not tags and not trackers:
+            self._fail_share_limit_rule(
+                rule_name=name,
+                message="at least one tag or tracker selector is required",
+            )
+
+        ratio_limit = raw_rule.get("ratio_limit")
+        seeding_time_limit = raw_rule.get("seeding_time_limit")
+        inactive_seeding_time_limit = raw_rule.get("inactive_seeding_time_limit")
+        share_limit_action = raw_rule.get("share_limit_action")
+
+        if (
+            ratio_limit is None
+            and seeding_time_limit is None
+            and inactive_seeding_time_limit is None
+            and share_limit_action is None
+        ):
+            self._fail_share_limit_rule(
+                rule_name=name,
+                message="at least one share limit value is required",
+            )
+
+        self._validate_ratio_limit(value=ratio_limit, rule_name=name)
+        self._validate_time_limit(
+            value=seeding_time_limit,
+            field_name="seeding_time_limit",
+            rule_name=name,
+        )
+        self._validate_time_limit(
+            value=inactive_seeding_time_limit,
+            field_name="inactive_seeding_time_limit",
+            rule_name=name,
+        )
+        self._validate_share_limit_action(
+            value=share_limit_action,
+            rule_name=name,
+        )
+
+        return ShareLimitRule(
+            name=name,
+            tags=tags,
+            trackers=trackers,
+            ratio_limit=ratio_limit,
+            seeding_time_limit=seeding_time_limit,
+            inactive_seeding_time_limit=inactive_seeding_time_limit,
+            share_limit_action=share_limit_action,
+        )
+
+    def _coerce_string_list(
+        self, *, value: Any, field_name: str, rule_name: str
+    ) -> list[str]:
+        if value is None:
+            return []
+
+        if isinstance(value, str):
+            values = [value]
+        else:
+            try:
+                values = list(value)
+            except TypeError:
+                self._fail_share_limit_rule(
+                    rule_name=rule_name,
+                    message=f"{field_name} must be a string or list of strings",
+                )
+
+        clean_values = []
+        for item in values:
+            if not isinstance(item, str):
+                self._fail_share_limit_rule(
+                    rule_name=rule_name,
+                    message=f"{field_name} must contain only strings",
+                )
+            item = item.strip()
+            if item:
+                clean_values.append(item)
+
+        return clean_values
+
+    def _validate_ratio_limit(self, *, value: Any, rule_name: str) -> None:
+        if value is None:
+            return
+
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            self._fail_share_limit_rule(
+                rule_name=rule_name,
+                message="ratio_limit must be a number",
+            )
+
+        if value < 0 and value not in {-1, -2}:
+            self._fail_share_limit_rule(
+                rule_name=rule_name,
+                message="ratio_limit must be -2, -1, or greater than or equal to 0",
+            )
+
+    def _validate_time_limit(
+        self, *, value: Any, field_name: str, rule_name: str
+    ) -> None:
+        if value is None:
+            return
+
+        if isinstance(value, bool) or not isinstance(value, int):
+            self._fail_share_limit_rule(
+                rule_name=rule_name,
+                message=f"{field_name} must be an integer number of minutes",
+            )
+
+        if value < 0 and value not in {-1, -2}:
+            self._fail_share_limit_rule(
+                rule_name=rule_name,
+                message=f"{field_name} must be -2, -1, or greater than or equal to 0",
+            )
+
+    def _validate_share_limit_action(self, *, value: Any, rule_name: str) -> None:
+        if value is None:
+            return
+
+        if value not in SUPPORTED_SHARE_LIMIT_ACTIONS:
+            actions = ", ".join(sorted(SUPPORTED_SHARE_LIMIT_ACTIONS))
+            self._fail_share_limit_rule(
+                rule_name=rule_name,
+                message=f"share_limit_action must be one of: {actions}",
+            )
+
+    def _fail_share_limit_rule(self, *, rule_name: str, message: str) -> None:
+        logging.error(f"Invalid share limit rule `{rule_name}`: {message}")
+        sys.exit(1)

--- a/src/torrent_manager.py
+++ b/src/torrent_manager.py
@@ -16,7 +16,7 @@ from src import (
     Limit,
     logging,
 )
-from torrent_configuration import TorrentConfiguration
+from torrent_configuration import ShareLimitRule, TorrentConfiguration
 
 
 class TorrentManager:
@@ -96,6 +96,41 @@ class TorrentManager:
                                 tracker_url=tracker_url,
                                 mapping_trackers=mapping_trackers,
                             )
+
+    def apply_share_limits(self) -> None:
+        """
+        Apply qBittorrent share limits to torrents matched by tag or tracker rules.
+        """
+        share_limit_rules = self.config.share_limits
+        if not share_limit_rules:
+            return
+
+        torrents = self.client.torrents_info()
+        tracker_cache = {}
+
+        for rule in share_limit_rules:
+            hashes = [
+                torrent.hash
+                for torrent in torrents
+                if self._torrent_matches_share_limit_rule(
+                    torrent=torrent,
+                    rule=rule,
+                    tracker_cache=tracker_cache,
+                )
+            ]
+
+            if not hashes:
+                logging.debug(f"No torrents matched share limit rule `{rule.name}`")
+                continue
+
+            self.client.torrents_set_share_limits(
+                ratio_limit=rule.ratio_limit,
+                seeding_time_limit=rule.seeding_time_limit,
+                inactive_seeding_time_limit=rule.inactive_seeding_time_limit,
+                share_limit_action=rule.share_limit_action,
+                torrent_hashes=hashes,
+            )
+            logging.debug(f"Applied share limit rule `{rule.name}` to {hashes}")
 
     def _retrieve_torrents_from_category(
         self,
@@ -246,6 +281,16 @@ class TorrentManager:
                     f"torrent {torrent_name} ~ {torrent_category} has finished downloading!"
                 )
 
+                if self._torrent_matches_share_limit_rule(torrent=torrent):
+                    logging.debug(
+                        f"torrent {torrent_name} ~ {torrent_category} is managed by share limits"
+                    )
+                    self._remove_from_storage(hash=torrent_hash)
+                    logging.debug(
+                        f"deleted {torrent_hash}, {len(self.storage)} torrents left in storage"
+                    )
+                    continue
+
                 self._pause_torrent(hash=torrent_hash)
 
                 logging.debug(
@@ -341,6 +386,92 @@ class TorrentManager:
             self.client.torrents_set_upload_limit(limit=limit, torrent_hashes=hashes)
         logging.debug(f"imposed {limit_operation.value} limit of {limit} for {hashes}")
 
+    def _torrent_matches_share_limit_rule(
+        self,
+        *,
+        torrent: qbittorrentapi.TorrentDictionary,
+        rule: ShareLimitRule | None = None,
+        tracker_cache: dict | None = None,
+    ) -> bool:
+        """
+        Check whether a torrent matches a configured share limit rule.
+
+        Tags inside one rule are OR'd, trackers inside one rule are OR'd, and if a
+        rule defines both selectors then both groups must match.
+        """
+        rules = [rule] if rule else self.config.share_limits
+        if not rules:
+            return False
+
+        for share_limit_rule in rules:
+            if self._torrent_matches_single_share_limit_rule(
+                torrent=torrent,
+                rule=share_limit_rule,
+                tracker_cache=tracker_cache,
+            ):
+                return True
+
+        return False
+
+    def _torrent_matches_single_share_limit_rule(
+        self,
+        *,
+        torrent: qbittorrentapi.TorrentDictionary,
+        rule: ShareLimitRule,
+        tracker_cache: dict | None,
+    ) -> bool:
+        tag_match = True
+        if rule.tags:
+            torrent_tags = self._retrieve_torrent_tags(torrent=torrent)
+            tag_match = any(tag in torrent_tags for tag in rule.tags)
+
+        tracker_match = True
+        if rule.trackers:
+            tracker_urls = self._retrieve_torrent_tracker_urls(
+                torrent=torrent,
+                tracker_cache=tracker_cache,
+            )
+            tracker_match = any(
+                tracker in tracker_url
+                for tracker in rule.trackers
+                for tracker_url in tracker_urls
+            )
+
+        return tag_match and tracker_match
+
+    def _retrieve_torrent_tags(
+        self, *, torrent: qbittorrentapi.TorrentDictionary
+    ) -> set[str]:
+        tags = torrent.tags
+        if isinstance(tags, str):
+            return {tag.strip() for tag in tags.split(",") if tag.strip()}
+
+        try:
+            return {tag.strip() for tag in tags if tag.strip()}
+        except TypeError:
+            return set()
+
+    def _retrieve_torrent_tracker_urls(
+        self,
+        *,
+        torrent: qbittorrentapi.TorrentDictionary,
+        tracker_cache: dict | None,
+    ) -> list[str]:
+        torrent_hash = torrent.hash
+        if tracker_cache is not None and torrent_hash in tracker_cache:
+            return tracker_cache[torrent_hash]
+
+        tracker_urls = [
+            tracker.get("url")
+            for tracker in torrent.trackers
+            if tracker.get("url") and tracker.get("url") not in IGNORED_TRACKER_URLS
+        ]
+
+        if tracker_cache is not None:
+            tracker_cache[torrent_hash] = tracker_urls
+
+        return tracker_urls
+
     def clean_procedure(self, *, category: str) -> None:
         """
         Removing all torrents (metadata **and** files) in `completed` or `paused` status for the specified category
@@ -389,6 +520,7 @@ class TorrentManager:
         Torrents with a time of completion which is >= than `CLEANER_MINUTES_THRESHOLD` will be removed.
         """
         current_time = datetime.now()
+        tracker_cache = {}
         for torrent in torrents_to_clean:
             torrent_name = torrent.get("name")
             torrent_hash = torrent.get("hash")
@@ -399,11 +531,35 @@ class TorrentManager:
                 f"{torrent_name} has been completed on {torrent_completed_time} ~ {diff_minutes} minutes ago"
             )
 
+            if self._stored_torrent_matches_share_limit_rule(
+                hash=torrent_hash,
+                tracker_cache=tracker_cache,
+            ):
+                logging.debug(
+                    f"{torrent_name} is managed by share limits, skipping cleaner"
+                )
+                continue
+
             if diff_minutes >= CLEANER_MINUTES_THRESHOLD:
                 self.client.torrents_delete(
                     torrent_hashes=torrent_hash, delete_files=True
                 )
                 logging.debug(f"Removed {torrent_name}")
+
+    def _stored_torrent_matches_share_limit_rule(
+        self, *, hash: str, tracker_cache: dict | None = None
+    ) -> bool:
+        if not self.config.share_limits:
+            return False
+
+        torrents = self.client.torrents_info(torrent_hashes=hash)
+        return any(
+            self._torrent_matches_share_limit_rule(
+                torrent=torrent,
+                tracker_cache=tracker_cache,
+            )
+            for torrent in torrents
+        )
 
     def resolve_data_discrepancies(self) -> None:
         """

--- a/tests/test_share_limits.py
+++ b/tests/test_share_limits.py
@@ -1,0 +1,307 @@
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+import torrent_configuration
+from src.torrent_manager import TorrentManager
+from torrent_configuration import ShareLimitRule, TorrentConfiguration
+
+
+class FakeState:
+    def __init__(self, *, is_downloading: bool):
+        self.is_downloading = is_downloading
+
+
+class FakeTorrent:
+    def __init__(
+        self,
+        *,
+        hash: str,
+        name: str = "torrent",
+        category: str = "",
+        tags="",
+        trackers=(),
+        progress: float = 1.0,
+        is_downloading: bool = False,
+    ):
+        self.hash = hash
+        self.name = name
+        self.category = category
+        self.tags = tags
+        self.progress = progress
+        self.state_enum = FakeState(is_downloading=is_downloading)
+        self._trackers = [{"url": tracker} for tracker in trackers]
+
+    @property
+    def trackers(self):
+        return self._trackers
+
+
+class FakeClient:
+    def __init__(self, torrents):
+        self.torrents = torrents
+        self.share_limit_calls = []
+        self.stopped_hashes = []
+        self.deleted_hashes = []
+
+    def torrents_info(self, torrent_hashes=None, **kwargs):
+        if not torrent_hashes:
+            return self.torrents
+
+        if isinstance(torrent_hashes, str):
+            hashes = set(torrent_hashes.split("|"))
+        else:
+            hashes = set(torrent_hashes)
+
+        return [torrent for torrent in self.torrents if torrent.hash in hashes]
+
+    def torrents_set_share_limits(self, **kwargs):
+        self.share_limit_calls.append(kwargs)
+
+    def torrents_stop(self, *, torrent_hashes):
+        self.stopped_hashes.append(torrent_hashes)
+
+    def torrents_delete(self, *, torrent_hashes, delete_files):
+        if delete_files:
+            self.deleted_hashes.append(torrent_hashes)
+
+
+class FakeConfig:
+    def __init__(self, share_limits):
+        self.share_limits = share_limits
+
+
+def build_manager(*, torrents, share_limits):
+    manager = TorrentManager.__new__(TorrentManager)
+    manager.client = FakeClient(torrents)
+    manager.config = FakeConfig(share_limits)
+    manager.storage = {}
+    return manager
+
+
+class ShareLimitRuleTests(unittest.TestCase):
+    def test_configuration_loads_share_limit_rules(self):
+        configuration = """
+[qbt]
+host = "localhost"
+port = 8080
+username = "admin"
+password = "password"
+
+[[share_limits]]
+name = "private tracker"
+tags = ["private"]
+trackers = ["tracker.example"]
+ratio_limit = 2.0
+seeding_time_limit = 10080
+inactive_seeding_time_limit = -2
+share_limit_action = "RemoveWithContent"
+"""
+
+        previous_config_path = torrent_configuration.CONFIG_PATH
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as config_file:
+            config_file.write(configuration)
+            config_file_path = config_file.name
+
+        try:
+            torrent_configuration.CONFIG_PATH = config_file_path
+            config = TorrentConfiguration()
+        finally:
+            torrent_configuration.CONFIG_PATH = previous_config_path
+            Path(config_file_path).unlink()
+
+        self.assertEqual(len(config.share_limits), 1)
+        rule = config.share_limits[0]
+        self.assertEqual(rule.name, "private tracker")
+        self.assertEqual(rule.tags, ["private"])
+        self.assertEqual(rule.trackers, ["tracker.example"])
+        self.assertEqual(rule.ratio_limit, 2.0)
+        self.assertEqual(rule.seeding_time_limit, 10080)
+        self.assertEqual(rule.inactive_seeding_time_limit, -2)
+        self.assertEqual(rule.share_limit_action, "RemoveWithContent")
+
+    def test_apply_share_limits_matches_tags(self):
+        rule = ShareLimitRule(
+            name="private",
+            tags=["private"],
+            ratio_limit=2.0,
+            seeding_time_limit=60,
+            share_limit_action="Stop",
+        )
+        manager = build_manager(
+            torrents=[
+                FakeTorrent(hash="match", tags="private, archive"),
+                FakeTorrent(hash="miss", tags="public"),
+            ],
+            share_limits=[rule],
+        )
+
+        manager.apply_share_limits()
+
+        self.assertEqual(len(manager.client.share_limit_calls), 1)
+        call = manager.client.share_limit_calls[0]
+        self.assertEqual(call["torrent_hashes"], ["match"])
+        self.assertEqual(call["ratio_limit"], 2.0)
+        self.assertEqual(call["seeding_time_limit"], 60)
+        self.assertEqual(call["share_limit_action"], "Stop")
+
+    def test_apply_share_limits_matches_trackers(self):
+        rule = ShareLimitRule(
+            name="tracker",
+            trackers=["tracker.example"],
+            ratio_limit=1.5,
+            share_limit_action="RemoveWithContent",
+        )
+        manager = build_manager(
+            torrents=[
+                FakeTorrent(
+                    hash="match",
+                    trackers=[
+                        "** [DHT] **",
+                        "https://tracker.example/announce",
+                    ],
+                ),
+                FakeTorrent(hash="miss", trackers=["https://other.example/announce"]),
+            ],
+            share_limits=[rule],
+        )
+
+        manager.apply_share_limits()
+
+        self.assertEqual(len(manager.client.share_limit_calls), 1)
+        call = manager.client.share_limit_calls[0]
+        self.assertEqual(call["torrent_hashes"], ["match"])
+        self.assertEqual(call["share_limit_action"], "RemoveWithContent")
+
+    def test_rule_with_tags_and_trackers_requires_both_groups_to_match(self):
+        rule = ShareLimitRule(
+            name="private tracker",
+            tags=["private"],
+            trackers=["tracker.example"],
+            seeding_time_limit=120,
+            share_limit_action="Stop",
+        )
+        manager = build_manager(
+            torrents=[
+                FakeTorrent(
+                    hash="match",
+                    tags="private",
+                    trackers=["https://tracker.example/announce"],
+                ),
+                FakeTorrent(
+                    hash="tag-only",
+                    tags="private",
+                    trackers=["https://other.example/announce"],
+                ),
+                FakeTorrent(
+                    hash="tracker-only",
+                    tags="public",
+                    trackers=["https://tracker.example/announce"],
+                ),
+            ],
+            share_limits=[rule],
+        )
+
+        manager.apply_share_limits()
+
+        self.assertEqual(len(manager.client.share_limit_calls), 1)
+        self.assertEqual(
+            manager.client.share_limit_calls[0]["torrent_hashes"],
+            ["match"],
+        )
+
+    def test_completed_share_managed_torrent_is_not_paused(self):
+        rule = ShareLimitRule(
+            name="private",
+            tags=["private"],
+            seeding_time_limit=60,
+            share_limit_action="Stop",
+        )
+        manager = build_manager(
+            torrents=[FakeTorrent(hash="managed", tags="private")],
+            share_limits=[rule],
+        )
+        manager.storage = {"managed": "Managed Torrent"}
+
+        manager.check_status()
+
+        self.assertEqual(manager.client.stopped_hashes, [])
+        self.assertNotIn("managed", manager.storage)
+
+    def test_completed_unmanaged_torrent_is_still_paused(self):
+        rule = ShareLimitRule(
+            name="private",
+            tags=["private"],
+            seeding_time_limit=60,
+            share_limit_action="Stop",
+        )
+        manager = build_manager(
+            torrents=[FakeTorrent(hash="unmanaged", tags="public")],
+            share_limits=[rule],
+        )
+        manager.storage = {"unmanaged": "Unmanaged Torrent"}
+
+        manager.check_status()
+
+        self.assertEqual(manager.client.stopped_hashes, ["unmanaged"])
+        self.assertNotIn("unmanaged", manager.storage)
+
+    def test_cleaner_skips_share_managed_torrent(self):
+        rule = ShareLimitRule(
+            name="private",
+            tags=["private"],
+            seeding_time_limit=60,
+            share_limit_action="RemoveWithContent",
+        )
+        manager = build_manager(
+            torrents=[FakeTorrent(hash="managed", tags="private")],
+            share_limits=[rule],
+        )
+        completed_at = int((datetime.now() - timedelta(hours=1)).timestamp())
+
+        manager._remove_torrents(
+            torrents_to_clean=[
+                {
+                    "hash": "managed",
+                    "name": "Managed Torrent",
+                    "completed_at": completed_at,
+                }
+            ]
+        )
+
+        self.assertEqual(manager.client.deleted_hashes, [])
+
+    def test_cleaner_still_deletes_unmanaged_torrent(self):
+        rule = ShareLimitRule(
+            name="private",
+            tags=["private"],
+            seeding_time_limit=60,
+            share_limit_action="RemoveWithContent",
+        )
+        manager = build_manager(
+            torrents=[FakeTorrent(hash="unmanaged", tags="public")],
+            share_limits=[rule],
+        )
+        completed_at = int((datetime.now() - timedelta(hours=1)).timestamp())
+
+        manager._remove_torrents(
+            torrents_to_clean=[
+                {
+                    "hash": "unmanaged",
+                    "name": "Unmanaged Torrent",
+                    "completed_at": completed_at,
+                }
+            ]
+        )
+
+        self.assertEqual(manager.client.deleted_hashes, ["unmanaged"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add configurable `[[share_limits]]` rules for matching torrents by tag, tracker, or both
- apply qBittorrent per-torrent ratio and seeding-time limits before the existing completion watchdog runs
- make share-limited torrents take priority over torrentManager's automatic pause and cleaner deletion flows
- document the new configuration and add a `1.2.3` changelog entry

Closes #19
